### PR TITLE
Add validation of required fields

### DIFF
--- a/keps/proposals_test.go
+++ b/keps/proposals_test.go
@@ -230,7 +230,7 @@ creation-date: 2018-04-15
 last-updated: 2018-04-24
 status: foo
 `,
-			expectedErrors: []error{fmt.Errorf("'foo' is not a valid status. The valid statuses are 'provisional', 'implementable', 'implemented', 'deferred', 'rejected', 'withdrawn', 'replaced'")},
+			expectedErrors: []error{fmt.Errorf("'foo' is not a valid status. Valid options are 'provisional', 'implementable', 'implemented', 'deferred', 'rejected', 'withdrawn', 'replaced'")},
 		},
 	}
 	for _, tc := range testcases {
@@ -242,7 +242,7 @@ status: foo
 			}
 			got := keps.Validate(kep)
 			if !reflect.DeepEqual(got, tc.expectedErrors) {
-				t.Errorf("expected errors: %v\ngot: %v", tc.expectedErrors, got)
+				t.Errorf("expected errors:\n%v\ngot:\n%v", tc.expectedErrors, got)
 			}
 		})
 

--- a/keps/proposals_test.go
+++ b/keps/proposals_test.go
@@ -1,6 +1,8 @@
 package keps_test
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -51,5 +53,198 @@ status: provisional
 				t.Fatal("out should not be nil")
 			}
 		})
+	}
+}
+
+func TestProposalValidation(t *testing.T) {
+	testcases := []struct {
+		name           string
+		content        string
+		expectedErrors []error
+	}{
+		{
+			name: "missing title",
+			content: `---
+#title: test
+authors:
+  - "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("title cannot be empty")},
+		},
+		{
+			name: "missing authors",
+			content: `---
+title: test
+#authors:
+#  - "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("authors list cannot be empty")},
+		},
+		{
+			name: "missing owning-sig",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+#owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("owning-sig cannot be empty")},
+		},
+		{
+			name: "missing reviewers",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+owning-sig: sig-api-machinery
+#reviewers:
+#  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("reviewers list cannot be empty")},
+		},
+		{
+			name: "missing approvers",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+#approvers:
+#  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("approvers list cannot be empty")},
+		},
+		{
+			name: "missing creation date",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+#creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("creation date cannot be empty")},
+		},
+		{
+			name: "missing last updated",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+#last-updated: 2018-04-24
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("last updated date cannot be empty")},
+		},
+		{
+			name: "last updated date is before creation date",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-14
+status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("last updated date must be later than creation date")},
+		},
+		{
+			name: "missing status",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+#status: provisional
+`,
+			expectedErrors: []error{fmt.Errorf("status cannot be empty")},
+		},
+		{
+			name: "invalid status",
+			content: `---
+title: test
+authors:
+- "@jpbetz"
+owning-sig: sig-api-machinery
+reviewers:
+  - "@deads2k"
+approvers:
+  - "@deads2k"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: foo
+`,
+			expectedErrors: []error{fmt.Errorf("'foo' is not a valid status. The valid statuses are 'provisional', 'implementable', 'implemented', 'deferred', 'rejected', 'withdrawn', 'replaced'")},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := keps.NewParser()
+			kep, err := p.Parse(strings.NewReader(tc.content))
+			if err != nil {
+				t.Errorf("error parsing proposal: %v", err)
+			}
+			got := keps.Validate(kep)
+			if !reflect.DeepEqual(got, tc.expectedErrors) {
+				t.Errorf("expected errors: %v\ngot: %v", tc.expectedErrors, got)
+			}
+		})
+
 	}
 }


### PR DESCRIPTION
This is an initial stab at validating the required fields of a KEP, and a couple of other data integrity checks (the last modified date must be after the creation date, the status must be valid).

I am curious about what you think of the `fieldValidator` approach, as I am a bit unsure about it. I added it as a separate commit. Also wondering if we should move this to another file (perhaps `validate.go`) but don't think that's critical at the moment.